### PR TITLE
Gradle 6.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-all.zip


### PR DESCRIPTION
Gradle 6.0 is available.

This is sent by @gradleupdate. See https://gradleupdate.appspot.com/matthiasbalke/gradle-kickstart/status for more.